### PR TITLE
Fix "Android build.gradle issues" page not showing up

### DIFF
--- a/docs/faq/android-build-gradle-issues.mdx
+++ b/docs/faq/android-build-gradle-issues.mdx
@@ -4,7 +4,7 @@ Starting with Flutter 2.8, the `compileSdkVersion`, `minSdkVersion` and `targetS
 
 Instead, they are set like this inside `android/app/build.gradle`:
 
-```gradle
+```
 android {
     compileSdkVersion flutter.compileSdkVersion
 


### PR DESCRIPTION
The gradle code highlight is not supported, page render crashes if used.
Docs.page worked on my fork and showed the page when gradle was removed.