### PR TITLE
Refactor AddToCartController to use a separate ItemQuantityController that is less error prone

### DIFF
--- a/ecommerce_app/lib/src/features/cart/presentation/add_to_cart/add_to_cart_controller.dart
+++ b/ecommerce_app/lib/src/features/cart/presentation/add_to_cart/add_to_cart_controller.dart
@@ -8,23 +8,30 @@ part 'add_to_cart_controller.g.dart';
 @riverpod
 class AddToCartController extends _$AddToCartController {
   @override
-  FutureOr<int> build() {
-    return 1;
-  }
-
-  void updateQuantity(int quantity) {
-    state = AsyncData(quantity);
+  FutureOr<void> build() {
+    // nothing to do
   }
 
   Future<void> addItem(ProductID productId) async {
     final cartService = ref.read(cartServiceProvider);
-    final item = Item(productId: productId, quantity: state.value!);
-    state = const AsyncLoading<int>().copyWithPrevious(state);
-    final value = await AsyncValue.guard(() => cartService.addItem(item));
-    if (value.hasError) {
-      state = AsyncError(value.error!, StackTrace.current);
-    } else {
-      state = const AsyncData(1);
+    final quantity = ref.read(itemQuantityControllerProvider);
+    final item = Item(productId: productId, quantity: quantity);
+    state = const AsyncLoading<void>();
+    state = await AsyncValue.guard(() => cartService.addItem(item));
+    if (!state.hasError) {
+      ref.read(itemQuantityControllerProvider.notifier).updateQuantity(1);
     }
+  }
+}
+
+@riverpod
+class ItemQuantityController extends _$ItemQuantityController {
+  @override
+  int build() {
+    return 1;
+  }
+
+  void updateQuantity(int quantity) {
+    state = quantity;
   }
 }

--- a/ecommerce_app/lib/src/features/cart/presentation/add_to_cart/add_to_cart_controller.g.dart
+++ b/ecommerce_app/lib/src/features/cart/presentation/add_to_cart/add_to_cart_controller.g.dart
@@ -30,20 +30,39 @@ class _SystemHash {
 }
 
 String $AddToCartControllerHash() =>
-    r'0238f81034cce3512a17fc50b91aba81ff5ac664';
+    r'9561d9e66460bf7ea99dce03b7a5900b38a7f930';
 
 /// See also [AddToCartController].
 final addToCartControllerProvider =
-    AutoDisposeAsyncNotifierProvider<AddToCartController, int>(
+    AutoDisposeAsyncNotifierProvider<AddToCartController, void>(
   AddToCartController.new,
   name: r'addToCartControllerProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : $AddToCartControllerHash,
 );
-typedef AddToCartControllerRef = AutoDisposeAsyncNotifierProviderRef<int>;
+typedef AddToCartControllerRef = AutoDisposeAsyncNotifierProviderRef<void>;
 
-abstract class _$AddToCartController extends AutoDisposeAsyncNotifier<int> {
+abstract class _$AddToCartController extends AutoDisposeAsyncNotifier<void> {
   @override
-  FutureOr<int> build();
+  FutureOr<void> build();
+}
+
+String $ItemQuantityControllerHash() =>
+    r'e3aebb6b912ee6ef8fd2ff6b1ab26201380f7862';
+
+/// See also [ItemQuantityController].
+final itemQuantityControllerProvider =
+    AutoDisposeNotifierProvider<ItemQuantityController, int>(
+  ItemQuantityController.new,
+  name: r'itemQuantityControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : $ItemQuantityControllerHash,
+);
+typedef ItemQuantityControllerRef = AutoDisposeNotifierProviderRef<int>;
+
+abstract class _$ItemQuantityController extends AutoDisposeNotifier<int> {
+  @override
+  int build();
 }

--- a/ecommerce_app/lib/src/features/cart/presentation/add_to_cart/add_to_cart_widget.dart
+++ b/ecommerce_app/lib/src/features/cart/presentation/add_to_cart/add_to_cart_widget.dart
@@ -19,12 +19,13 @@ class AddToCartWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<AsyncValue<int>>(
+    ref.listen<AsyncValue>(
       addToCartControllerProvider,
       (_, state) => state.showAlertDialogOnError(context),
     );
     final availableQuantity = ref.watch(itemAvailableQuantityProvider(product));
     final state = ref.watch(addToCartControllerProvider);
+    final quantity = ref.watch(itemQuantityControllerProvider);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -34,14 +35,14 @@ class AddToCartWidget extends ConsumerWidget {
           children: [
             Text('Quantity:'.hardcoded),
             ItemQuantitySelector(
-              quantity: state.value!,
+              quantity: quantity,
               // let the user choose up to the available quantity or
               // 10 items at most
               maxQuantity: min(availableQuantity, 10),
               onChanged: state.isLoading
                   ? null
                   : (quantity) => ref
-                      .read(addToCartControllerProvider.notifier)
+                      .read(itemQuantityControllerProvider.notifier)
                       .updateQuantity(quantity),
             ),
           ],

--- a/ecommerce_app/test/src/features/cart/presentation/add_to_cart/add_to_cart_controller_test.dart
+++ b/ecommerce_app/test/src/features/cart/presentation/add_to_cart/add_to_cart_controller_test.dart
@@ -34,40 +34,54 @@ void main() {
         (_) => Future.value(null),
       );
       final container = makeProviderContainer(cartService);
-      final controller = container.read(addToCartControllerProvider.notifier);
-      final listener = Listener<AsyncValue<int>>();
+      // add to cart controller
+      final addToCartController =
+          container.read(addToCartControllerProvider.notifier);
+      final addToCartListener = Listener<AsyncValue<void>>();
       container.listen(
         addToCartControllerProvider,
-        listener,
+        addToCartListener,
+        fireImmediately: true,
+      );
+      // item quantity controller
+      final itemQuantityController =
+          container.read(itemQuantityControllerProvider.notifier);
+      final itemQuantityListener = Listener<int>();
+      container.listen(
+        itemQuantityControllerProvider,
+        itemQuantityListener,
         fireImmediately: true,
       );
       // run
-      const initialData = AsyncData<int>(1);
+      const initialData = AsyncData<void>(null);
       // the build method returns a value immediately, so we expect AsyncData
-      verify(() => listener(null, initialData));
+      verify(() => addToCartListener(null, initialData));
+      verify(() => itemQuantityListener(null, 1));
       // update quantity
-      controller.updateQuantity(quantity);
+      itemQuantityController.updateQuantity(quantity);
       // the quantity is updated
-      verify(() => listener(initialData, const AsyncData<int>(quantity)));
+      verify(() => itemQuantityListener(1, quantity));
       // add item
-      await controller.addItem(productId);
+      await addToCartController.addItem(productId);
       verifyInOrder(
         [
           // the loading state is set
-          () => listener(
-                const AsyncData<int>(quantity),
-                const AsyncLoading<int>()
-                    .copyWithPrevious(const AsyncData<int>(quantity)),
+          () => addToCartListener(
+                initialData,
+                any(that: isA<AsyncLoading>()),
               ),
           // then the data is set with quantity: 1
-          () => listener(
-                const AsyncLoading<int>()
-                    .copyWithPrevious(const AsyncData<int>(quantity)),
+          () => addToCartListener(
+                any(that: isA<AsyncLoading>()),
                 initialData,
               ),
         ],
       );
-      verifyNoMoreInteractions(listener);
+      // on success, quantity goes back to 1
+      verify(() => itemQuantityListener(quantity, 1));
+      // then, no more interactions
+      verifyNoMoreInteractions(addToCartListener);
+      verifyNoMoreInteractions(itemQuantityListener);
       verify(() => cartService.addItem(item)).called(1);
     });
 
@@ -78,41 +92,53 @@ void main() {
       when(() => cartService.addItem(item))
           .thenThrow((_) => Exception('Connection failed'));
       final container = makeProviderContainer(cartService);
-      final controller = container.read(addToCartControllerProvider.notifier);
-      final listener = Listener<AsyncValue<int>>();
+      // add to cart controller
+      final addToCartController =
+          container.read(addToCartControllerProvider.notifier);
+      final addToCartListener = Listener<AsyncValue<void>>();
       container.listen(
         addToCartControllerProvider,
-        listener,
+        addToCartListener,
         fireImmediately: true,
       );
-      const initialData = AsyncData<int>(1);
-      // the build method returns a value immediately, so we expect AsyncData
-      verify(() => listener(null, initialData));
-      // update quantity
-      controller.updateQuantity(quantity);
-      // the quantity is updated
-      verify(
-        () => listener(initialData, const AsyncData<int>(quantity)),
+      // item quantity controller
+      final itemQuantityController =
+          container.read(itemQuantityControllerProvider.notifier);
+      final itemQuantityListener = Listener<int>();
+      container.listen(
+        itemQuantityControllerProvider,
+        itemQuantityListener,
+        fireImmediately: true,
       );
+      // run
+      const initialData = AsyncData<void>(null);
+      // the build method returns a value immediately, so we expect AsyncData
+      verify(() => addToCartListener(null, initialData));
+      verify(() => itemQuantityListener(null, 1));
+      // update quantity
+      itemQuantityController.updateQuantity(quantity);
+      // the quantity is updated
+      verify(() => itemQuantityListener(1, quantity));
       // add item
-      await controller.addItem(productId);
+      await addToCartController.addItem(productId);
       verifyInOrder(
         [
           // the loading state is set
-          () => listener(
-                const AsyncData<int>(quantity),
-                const AsyncLoading<int>()
-                    .copyWithPrevious(const AsyncData<int>(quantity)),
+          () => addToCartListener(
+                initialData,
+                any(that: isA<AsyncLoading>()),
               ),
-          // then an error is set
-          () => listener(
-                const AsyncLoading<int>()
-                    .copyWithPrevious(const AsyncData<int>(quantity)),
+          // then the data is set with quantity: 1
+          () => addToCartListener(
+                any(that: isA<AsyncLoading>()),
                 any(that: isA<AsyncError>()),
               ),
         ],
       );
-      verifyNoMoreInteractions(listener);
+      // on error, quantity doesn't change
+      // then, no more interactions
+      verifyNoMoreInteractions(addToCartListener);
+      verifyNoMoreInteractions(itemQuantityListener);
       verify(() => cartService.addItem(item)).called(1);
     });
   });


### PR DESCRIPTION
This fixes an issue that is caused when an exception is thrown by the method below when adding an item to the cart:

```dart
class SembastCartRepository implements LocalCartRepository {
  ...
  @override
  Future<void> setCart(Cart cart) {
    throw StateError('Something went wrong');
    //return store.record(cartItemsKey).put(db, cart.toJson());
  }
}
```

This is caused by the unsafe usage of `state.value!` when setting the quantity in this widget:

```dart
ItemQuantitySelector(
  quantity: state.value!, // this will blow up if there was an error
  ...
)
```

To address this:

- `AddToCartController` has been modified to hold a `void` state (no longer `int`)
- a new `ItemQuantityController` has been introduce to keep track of the quantity independently

This way, even if an error occurs, it's still possible to read the quantity.
